### PR TITLE
Bump deps and use ecma version 2019

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ module.exports = {
     'standard'
   ],
   parserOptions: {
-    ecmaVersion: 8
+    ecmaVersion: '2019'
   },
   plugins: [],
   rules: {

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@ministryofjustice/eslint-config-fb",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Default Form Builder eslint config",
   "main": "index.js",
   "scripts": {
     "test": "tape spec/**/*.unit.spec.js"
   },
   "dependencies": {
-    "eslint": "^5.15.3",
+    "eslint": "^5.16.0",
     "eslint-config-standard": "^12.0.0",
-    "eslint-plugin-import": "^2.16.0",
-    "eslint-plugin-node": "^8.0.1",
-    "eslint-plugin-promise": "^4.0.1",
+    "eslint-plugin-import": "^2.17.2",
+    "eslint-plugin-node": "^9.0.0",
+    "eslint-plugin-promise": "^4.1.1",
     "eslint-plugin-standard": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Not sure exactly how we do NPM releases...so just bumped it in this PR